### PR TITLE
De-indent the JS include, so won't confuse embeds in markdown docs

### DIFF
--- a/py/langevitour/langevitour.py
+++ b/py/langevitour/langevitour.py
@@ -224,20 +224,20 @@ class Langevitour:
         js_content = self._get_js_content()
 
         html = f"""
-        <div id="{unique_id}"></div>
-        <script>
-            if ('el_{unique_id}' in window) {{
-                // ensure that the previous instance is cleaned up
-                delete window.el_{unique_id};
-                delete window.tour_{unique_id};
-            }}
+<div id="{unique_id}"></div>
+<script>
+    if ('el_{unique_id}' in window) {{
+        // ensure that the previous instance is cleaned up
+        delete window.el_{unique_id};
+        delete window.tour_{unique_id};
+    }}
 
-            {js_content}
+    {js_content}
 
-            var el_{unique_id} = document.getElementById("{unique_id}");
-            var tour_{unique_id} = new langevitour.Langevitour(el_{unique_id}, {self.width}, {self.height});
-            tour_{unique_id}.renderValue({data_json});
-        </script>
+    var el_{unique_id} = document.getElementById("{unique_id}");
+    var tour_{unique_id} = new langevitour.Langevitour(el_{unique_id}, {self.width}, {self.height});
+    tour_{unique_id}.renderValue({data_json});
+</script>
         """
         return html
 


### PR DESCRIPTION
Hi! I'm excited about your tool, and am including it in my toolkit for analysis of vote matrices used in democratic processes :)

https://github.com/patcon/valency-anndata

When working on a documentation website, I realized that the way you're indenting was confusing nbconvert when it was converting from python notebook into markdown file. These markdown documents accept script tags, but assume deep indentation is a code block, and so the widget wasn't working.

Here's a minimal PR that fixes it!

## Before
<img width="778" height="651" alt="Screenshot 2025-12-29 at 10 59 02 PM" src="https://github.com/user-attachments/assets/918e87db-d715-4464-bbe1-1cc44efa1438" />

## After
<img width="1020" height="638" alt="Screenshot 2025-12-29 at 11 03 12 PM" src="https://github.com/user-attachments/assets/b24b597d-d549-4f44-8eba-1823a94fc49a" />

Example page in rendered website is here for now, but might move:
https://patcon.github.io/valency-anndata/notebooks-autogenerated/example-usage/